### PR TITLE
Add .npmrc with legacy-peer-deps to fix Vercel deployment

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
@formspree/react@2.5.1 has not declared support for React 19 yet, causing npm install to fail on Vercel without this flag.